### PR TITLE
[WIP]: Run model fitting and label prediction on a separate thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VSCode
+.vscode

--- a/src/cryocanvas/app.py
+++ b/src/cryocanvas/app.py
@@ -184,6 +184,7 @@ class CryoCanvasApp:
         if np.any(training_labels.shape == 0):
             self.logger.info("No training data yet. Skipping model update")
         elif live_fit:
+            self.widget.status.setText("Fitting model ...")
             self.fit_model_task = self.executor.submit(
                 self.fit_model,
                 training_labels,
@@ -291,6 +292,7 @@ class CryoCanvasApp:
             else:
                 prediction_features = np.array(self.feature_data_tomotwin)
             
+            self.widget.status.setText("Predicting labels ...")
             self.predict_task = self.executor.submit(self.predict, prediction_features)
             self.predict_task.add_done_callback(self.on_prediction)
 
@@ -307,6 +309,7 @@ class CryoCanvasApp:
         self.logger.info("update charts")
         self.update_class_distribution_charts()
         self.logger.info("finished")
+        self.widget.status.setText("Ready")
 
     def fit_model(self, labels, features, model_type):
         self.logger.info("fit_model")
@@ -567,7 +570,7 @@ class CryoCanvasWidget(QWidget):
         layout.addWidget(self.canvas)
 
         # Add status log
-        self.status = QLabel()
+        self.status = QLabel("Ready")
         layout.addWidget(self.status)
 
         self.setLayout(layout)


### PR DESCRIPTION
This makes cryocanvas much less frustrating to use on my Intel macbook pro by mostly freeing up the main thread to let me paint.

The approach of using `ThreadPoolExecutor` is probably not the right one. Given we know this is a napari plugin with Qt widgets around, we should likely use the qt thread worker decorators and helper functions to simplify the code a little here and maybe have some better guarantees around thread safety (though i'm not sure how much we need them here).

I also did some refactoring, mostly to reason about the operations and state changes in this code path. I'm not sure how useful those are to others, but it might be worth considering something similar.

This is a work-in-progress and definitely not safe to merge!